### PR TITLE
issue #3

### DIFF
--- a/MedicatioNeura/AppDelegate.swift
+++ b/MedicatioNeura/AppDelegate.swift
@@ -12,13 +12,19 @@
 
 import UIKit
 import NeuraSDK
+import UserNotifications
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        if #available(iOS 10.0, *) {
+            UNUserNotificationCenter.current().delegate = self
+        } else {
+            // Fallback on earlier versions
+        }
         NeuraSDKManager.manager.setup()
         application.applicationIconBadgeNumber = 0
         return true
@@ -26,6 +32,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         NeuraSDKManager.manager.userRegisteredForRemoteNotifications(tokenData: deviceToken)
+    }
+    
+    @available(iOS 10.0, *)
+    func userNotificationCenter(_ center: UNUserNotificationCenter,  willPresent notification: UNNotification, withCompletionHandler   completionHandler: @escaping (_ options:   UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.badge, .alert, .sound])
+    }
+    
+    @available(iOS 10.0, *)
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        guard
+            let eventIdentifier = response.notification.request.content.userInfo["event_type"] as? String
+            else {
+                return
+        }
+        
+        self.handleAction(identifier: kTookActionIdentifier, eventIdentifier: eventIdentifier)
+        completionHandler()
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Alamofire (4.3.0)
-  - NeuraSDKFramework (3.0.0)
+  - Alamofire (4.4.0)
+  - NeuraSDKFramework (3.2.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.3)
   - NeuraSDKFramework
 
 SPEC CHECKSUMS:
-  Alamofire: 856a113053a7bc9cbe5d6367a555d773fc5cfef7
-  NeuraSDKFramework: 894b6e7cc21d7219ab13bfa8bf6eb8a4afea0d26
+  Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
+  NeuraSDKFramework: 3bd2fa691d9d168adb9cdf9c63aec77f21537688
 
 PODFILE CHECKSUM: ee240579bbd688d3f0e24ed317b68d70afe902d8
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0


### PR DESCRIPTION
Deprecated Local and Push notifications categories and actions are broken on 10.3

You’ll get a notification, but without the actions associated with the categories

Added use of the newly introduced Notification Center with previous iOS versions support